### PR TITLE
Implement dataset finalization without file move

### DIFF
--- a/rbs_client/upload_dataset.py
+++ b/rbs_client/upload_dataset.py
@@ -83,6 +83,17 @@ def upload_dataset_to_server(dataset_name: str, dataset_root: str, server_url: s
 
         print(f"\nЗагружено {success}/{len(files)} файлов.")
 
+        # Завершаем создание датасета
+        save_url = f"{server_url.rstrip('/')}/save-dataset/"
+        try:
+            resp = requests.post(save_url, params={"dataset_name": dataset_name}, timeout=10)
+            if resp.status_code == 200:
+                print("Датасет сохранён на сервере")
+            else:
+                print(f"Ошибка сохранения: {resp.status_code} {resp.text}")
+        except RequestException as e:
+            print(f"Ошибка при запросе save-dataset: {e}")
+
 # Пример запуска
 if __name__ == "__main__":
     upload_dataset_to_server(


### PR DESCRIPTION
## Summary
- update `save_dataset` to set status to `SAVE` without moving cached files
- call `/save-dataset` at the end of `upload_dataset_to_server`

## Testing
- `python -m py_compile rbs_cloud.py rbs_client/upload_dataset.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b865ac4788331b7db13e2b485acc3